### PR TITLE
Laravel 8.x では excludeUnvalidatedArrayKeys を明示的に有効化

### DIFF
--- a/src/app/Providers/AppServiceProvider.php
+++ b/src/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -20,5 +21,8 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         Schema::defaultStringLength(191);
+
+        // Laravel 8.x では excludeUnvalidatedArrayKeys のデフォルト値が false なので明示的に有効化
+        Validator::excludeUnvalidatedArrayKeys();
     }
 }


### PR DESCRIPTION
[Kubectl Set Image · mpyw-yattemita/phperkaigi2023-laravel-newrelic-performance@773e810](https://github.com/mpyw-yattemita/phperkaigi2023-laravel-newrelic-performance/actions/runs/4340679424/jobs/7579449680) でお試しデプロイ