### PR TITLE
PHP 8.2 & New Relic Agent 10.7.0.319

### DIFF
--- a/.github/workflows/kubectl.yaml
+++ b/.github/workflows/kubectl.yaml
@@ -82,7 +82,7 @@ jobs:
           cache-to: type=gha,mode=max
           # このオプションは JavaScript でパースされており，シェルのパース規則と異なるので，意図的にダブルクオートは使わない
           build-args: |
-            NEW_RELIC_AGENT_VERSION=10.6.0.318
+            NEW_RELIC_AGENT_VERSION=10.7.0.319
             VITE_GITHUB_URL=${{ inputs.VITE_GITHUB_URL }}
             VITE_NEW_RELIC_URL=${{ inputs.VITE_NEW_RELIC_URL }}
           tags: |

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,7 +6,7 @@ services:
       dockerfile: ./infra/docker/php/Dockerfile
       target: php_fpm_customized_with_xdebug
       args:
-        NEW_RELIC_AGENT_VERSION: 10.6.0.318
+        NEW_RELIC_AGENT_VERSION: 10.7.0.319
         VITE_GITHUB_URL: ${VITE_GITHUB_URL:-https://github.com/mpyw-yattemita/phperkaigi2023-laravel-newrelic-performance}
         VITE_NEW_RELIC_URL: ${VITE_NEW_RELIC_URL:-https://one.newrelic.com/nr1-core}
     entrypoint: docker-php-entrypoint-local

--- a/infra/docker/php/Dockerfile
+++ b/infra/docker/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-fpm-bullseye AS php_fpm_customized
+FROM php:8.2-fpm-bullseye AS php_fpm_customized
 
 WORKDIR /workspace
 


### PR DESCRIPTION
[Hub Topic: [PHP] Support for PHP 8.2](https://forum.newrelic.com/s/hubtopic/aAX8W0000008e0hWAA/php-support-for-php-82)

---

PHP 8.2 で若干パフォーマンス落ちてるなぁって思ったけど，ベンチマーク的にも明らかっぽい。

- [PHP Benchmarks - What PHP Version is the fastest?](https://onlinephp.io/benchmarks)

ワイルドカードレスバリデーションが， 25 秒ぐらいで済んでいた場合が 29 秒まで伸びてる

---

~デモとして遅くなるの嫌なので，このまま残しておきますか…ｗ~

closes #7
